### PR TITLE
Resolves #9: daily tasks not working as intended

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
+	"os/user"
+	"path"
 
+	"github.com/luis-octavius/akrasia/pkg/cron"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +16,7 @@ var (
 	name        string
 	description string
 	priority    string
-	// todoTime    []int
-	date []int
+	date        []int
 )
 
 var rootCmd = &cobra.Command{
@@ -42,28 +41,60 @@ func Execute() {
 	}
 }
 
-var detached = &cobra.Command{
-	Use:   "detached",
-	Short: "Initialize the daemon that executes in background",
-	Long:  "detached mode enables the program to run in the background to update the daily todos everyday",
-	Run: func(cmd *cobra.Command, args []string) {
-		ticker := time.NewTicker(24 * time.Hour)
-		sigChan := make(chan os.Signal, 1)
-
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				cfg.updateDailyTodo()
-			case sig := <-sigChan:
-				fmt.Printf("\nsignal received: %v\n", sig)
-				fmt.Println("shutting down detached mode gracefully...")
-				return
-			}
+var createDailyUpdate = &cobra.Command{
+	Use:     "create-cron",
+	Short:   "create the cron job to update daily tasks",
+	Aliases: []string{"cc"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		user, err := user.Current()
+		if err != nil {
+			return fmt.Errorf("error getting user: %v", err)
 		}
+
+		schedule := "00 15 * * *"
+
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("error getting home dir: %v", err)
+		}
+
+		akrasiaCommand := path.Join(homePath, "go/bin/akrasia") + " upd"
+
+		name := "createUpdateDaily"
+
+		comment := "update daily todos in akrasia app"
+
+		manager := cron.NewManager()
+
+		if err := manager.ValidateSchedule(schedule); err != nil {
+			return fmt.Errorf("invalid schedule format: %v", err)
+		}
+
+		err = manager.AddJob(name, schedule, akrasiaCommand, user.Username, comment)
+		if err != nil {
+			return fmt.Errorf("invalid job format: %v", err)
+		}
+
+		fmt.Printf("cron job '%s' created successfully\n", name)
+		if user.Username != "" {
+			fmt.Printf("\nUser: %s\n", user)
+		}
+
+		return nil
+	},
+}
+
+var updateDailyTodo = &cobra.Command{
+	Use:     "update-daily",
+	Short:   "update daily todos",
+	Aliases: []string{"upd"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := cfg.updateDailyTodo()
+		if err != nil {
+			return fmt.Errorf("error in update daily todo: %v", err)
+		}
+
+		return nil
 	},
 }
 
@@ -237,6 +268,7 @@ func init() {
 	rootCmd.AddCommand(checkExpired)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(delByName)
-	rootCmd.AddCommand(detached)
+	rootCmd.AddCommand(updateDailyTodo)
+	rootCmd.AddCommand(createDailyUpdate)
 	delByName.Flags().StringVar(&name, "name", "", "todo name")
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pressly/goose v2.7.0+incompatible // indirect
 	github.com/pressly/goose/v3 v3.26.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/pressly/goose/v3 v3.26.0 h1:KJakav68jdH0WDvoAcj8+n61WqOIaPGgH0bJWS6jp
 github.com/pressly/goose/v3 v3.26.0/go.mod h1:4hC1KrritdCxtuFsqgs1R4AU5bWtTAf+cnWvfhf2DNY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=

--- a/internal/database/todos.sql.go
+++ b/internal/database/todos.sql.go
@@ -73,7 +73,7 @@ func (q *Queries) AutoCompleteDelete(ctx context.Context, dollar_1 sql.NullStrin
 
 const checkExpired = `-- name: CheckExpired :many
 SELECT id, name, description, created_at, updated_at, concluded, expires_at, priority, is_daily FROM todos 
-WHERE expires_at < datetime('now')
+WHERE expires_at < datetime('now') AND is_daily = false
 ORDER BY expires_at DESC
 `
 
@@ -204,7 +204,7 @@ func (q *Queries) GetTodos(ctx context.Context) ([]Todo, error) {
 const updateDailyTodo = `-- name: UpdateDailyTodo :many
 UPDATE todos 
 SET expires_at = ?, updated_at = datetime('now')
-WHERE is_daily = true
+WHERE is_daily = true AND date(expires_at) <= date('now') 
 RETURNING id, name, description, created_at, updated_at, concluded, expires_at, priority, is_daily
 `
 

--- a/pkg/cron/manager.go
+++ b/pkg/cron/manager.go
@@ -1,0 +1,163 @@
+package cron
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/robfig/cron/v3"
+)
+
+type Manager struct {
+	parser cron.Parser
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		parser: cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow),
+	}
+}
+
+// ValidateSchedule checks if a given schedule is valid
+func (m *Manager) ValidateSchedule(schedule string) error {
+	_, err := m.parser.Parse(schedule)
+	return err
+}
+
+// AddJob adds a new cron job to the system crontab
+func (m *Manager) AddJob(name, schedule, command, user, comment string) error {
+	// get current crontab
+	// Crontab manages the crontab user table files
+	currentCron, err := m.getCurrentCrontab(user)
+	if err != nil {
+		return fmt.Errorf("failed to get current crontab: %v", err)
+	}
+
+	if m.jobExists(currentCron, name) {
+		return fmt.Errorf("job with name '%s' already exists", name)
+	}
+
+	newEntry := m.buildCronEntry(name, schedule, command, comment)
+
+	newCrontab := currentCron
+	if newCrontab != "" && !strings.HasSuffix(newCrontab, "\n") {
+		newCrontab += "\n"
+	}
+	newCrontab += newEntry + "\n"
+
+	return m.writeCrontab(newCrontab)
+}
+
+// buildCronEntry creates a formatted cron entry
+func (m *Manager) buildCronEntry(name, schedule, command, comment string) string {
+	var builder strings.Builder
+
+	if comment != "" {
+		builder.WriteString(fmt.Sprintf("# %s\n", comment))
+	}
+
+	// add marker for the job name to easily identify
+	builder.WriteString(fmt.Sprintf("# JOB_NAME=%s\n", name))
+	builder.WriteString(fmt.Sprintf("%s %s\n", schedule, command))
+
+	return builder.String()
+}
+
+func (m *Manager) getCurrentCrontab(user string) (string, error) {
+	var cmd *exec.Cmd
+
+	if user != "" {
+		cmd = exec.Command("crontab", "-u", user, "-l")
+	} else {
+		cmd = exec.Command("crontab", "-l")
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		// crontab might not exist
+		return "", nil
+	}
+
+	return string(output), nil
+}
+
+// writeCrontab writes the crontab content
+func (m *Manager) writeCrontab(content string) error {
+	tmpFile, err := os.CreateTemp("", "crontab-*.txt")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	var cmd *exec.Cmd
+	cmd = exec.Command("crontab", tmpFile.Name())
+
+	if err := cmd.Run(); err != nil {
+		fmt.Println(cmd.Output())
+		return fmt.Errorf("failed to install crontab: %v", err)
+	}
+
+	return nil
+}
+
+// jobExists checks if a job with the given name already exists
+func (m *Manager) jobExists(crontab, name string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(crontab))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, fmt.Sprintf("JOB_NAME=%s", name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) ListJobs(user string) ([]map[string]string, error) {
+	crontab, err := m.getCurrentCrontab(user)
+	if err != nil {
+		return nil, err
+	}
+
+	var jobs []map[string]string
+	scanner := bufio.NewScanner(strings.NewReader(crontab))
+
+	var currentJob map[string]string
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "# JOB_NAME=") {
+			// start of a new job
+			if currentJob != nil {
+				jobs = append(jobs, currentJob)
+			}
+			currentJob = make(map[string]string)
+			currentJob["name"] = strings.TrimPrefix(line, "# JOB_NAME=")
+		} else if strings.HasPrefix(line, "#") && currentJob != nil {
+			// job comment
+			currentJob["comment"] = strings.TrimPrefix(line, "# ")
+		} else if line != "" && !strings.HasPrefix(line, "#") && currentJob != nil {
+			// the actual cron job line
+			parts := strings.Fields(line)
+			if len(parts) >= 6 {
+				currentJob["schedule"] = strings.Join(parts[:5], " ")
+				currentJob["command"] = strings.Join(parts[5:], " ")
+			}
+		}
+	}
+
+	// sees if there is still a job
+	if currentJob != nil {
+		jobs = append(jobs, currentJob)
+	}
+
+	return jobs, nil
+}

--- a/sql/queries/todos.sql
+++ b/sql/queries/todos.sql
@@ -25,7 +25,7 @@ RETURNING *;
 -- name: UpdateDailyTodo :many
 UPDATE todos 
 SET expires_at = ?, updated_at = datetime('now')
-WHERE is_daily = true
+WHERE is_daily = true AND date(expires_at) <= date('now') 
 RETURNING *;  
 
 -- name: DeleteTodoByName :exec 
@@ -38,7 +38,7 @@ WHERE concluded = true;
 
 -- name: CheckExpired :many 
 SELECT * FROM todos 
-WHERE expires_at < datetime('now')
+WHERE expires_at < datetime('now') AND is_daily = false
 ORDER BY expires_at DESC;
 
 -- name: AutoCompleteDelete :one 

--- a/task.go
+++ b/task.go
@@ -154,9 +154,16 @@ func (cfg *Config) updateDailyTodo() error {
 		Time:  time.Now().Add(24 * time.Hour),
 		Valid: true,
 	}
+
 	todos, err := cfg.Queries.UpdateDailyTodo(context.Background(), expiresAt)
 	if err != nil {
 		return fmt.Errorf("error updating daily todos: %w", err)
+	}
+
+	if len(todos) == 0 {
+		fmt.Println("no tasks to be updated")
+	} else {
+		fmt.Println("tasks updated successfully!")
 	}
 
 	// just for debugging


### PR DESCRIPTION
### Description 
To update daily tasks, the app has to be running as a background process in the system. With the command:  
  
```bash 
akrasia detached & #& is to not lose the terminal window that you're at
``` 

When I developed this, it was, for me, a way to handle this forcefully, not gracefully. Thinking about it days ago, I came up with a solution more robust and efficient. It was tough to implement, but more reliable. 

### Steps 
- I have created a package named `cron` in `pkg` that creates a manager for crontabs using [cron](github.com/robfig/cron/v3) to create a job in the system that updates daily tasks. The package has methods to adding a job, seeing if a job already exists, list existing jobs and writing crontabs.
- Created two commands:  `createDailyUpdate` and `updateDailyTodo`. 
1) `createDailyUpdate`: uses the package `cron` in pkg to create a manager and construct the cronjob from provided arguments. 
2) `updateDailyTodo`: just execute the query to update daily tasks.
- Updated the query 'UpdateDailyTodo' to not only adds a day into daily tasks, but includes a check to see if the `expires_at` field expired yesterday or today. That was an interesting one: 

```sql
UPDATE todos 
SET expires_at = ?, updated_at = datetime('now')
WHERE is_daily = true AND date(expires_at) <= date('now') 
RETURNING *;  
```

Before this check the query updates every time, so, in this manner, every time the update daily todo command runs it adds a day into the task. That is not the way that I've intended, and I've come up with this fix. 