### PR TITLE
fix[delete-by-name]

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -306,6 +306,10 @@ var delByName = &cobra.Command{
 	Short:   "delete a todo by name",
 	Aliases: []string{"deln", "dn"},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !deleteYes {
+			return errors.New("destructive action blocked: use --yes to confirm")
+		}
+
 		err := cfg.deleteByName(name)
 		if err != nil {
 			return err
@@ -414,6 +418,7 @@ func init() {
 	focus.Flags().StringVar(&filterPriority, "priority", "", "filter tasks by priority: high|medium|low")
 	getTodoByName.Flags().StringVar(&name, "name", "", "task name")
 	delByName.Flags().StringVar(&name, "name", "", "todo name")
+	delByName.Flags().BoolVar(&deleteYes, "yes", false, "confirm destructive deletion of concluded tasks")
 	updateStatusToConcluded.Flags().StringVar(&name, "name", "", "task name")
 	updateStatusToConcluded.Flags().StringVar(&notes, "notes", "", "daily notes")
 	deleteConcluded.Flags().BoolVar(&deleteYes, "yes", false, "confirm destructive deletion of concluded tasks")

--- a/internal/database/todos.sql.go
+++ b/internal/database/todos.sql.go
@@ -122,7 +122,7 @@ func (q *Queries) DeleteConcluded(ctx context.Context) error {
 
 const deleteTodoByName = `-- name: DeleteTodoByName :exec
 DELETE FROM todos 
-WHERE name LIKE ?
+WHERE name = ?
 `
 
 func (q *Queries) DeleteTodoByName(ctx context.Context, name string) error {

--- a/sql/queries/todos.sql
+++ b/sql/queries/todos.sql
@@ -51,7 +51,7 @@ WHERE is_daily = true
 RETURNING *;
 -- name: DeleteTodoByName :exec 
 DELETE FROM todos 
-WHERE name LIKE ?;
+WHERE name = ?;
 
 -- name: DeleteConcluded :exec 
 DELETE FROM todos 

--- a/task.go
+++ b/task.go
@@ -262,12 +262,22 @@ func (cfg *Config) checkExpiring() error {
 
 // deleteByName removes one task identified by name.
 func (cfg *Config) deleteByName(name string) error {
-	err := cfg.Queries.DeleteTodoByName(context.Background(), name)
+	todo, err := cfg.Queries.GetTodoByName(context.Background(), database.GetTodoByNameParams{
+		LOWER:   name,
+		LOWER_2: name,
+		LOWER_3: name,
+		LOWER_4: name,
+	})
 	if err != nil {
-		return fmt.Errorf("Error deleting task: %w", err)
+		return fmt.Errorf("error getting todo by name: %w", err)
 	}
 
-	color.MsgSuccess(SuccessDelete)
+	err = cfg.Queries.DeleteTodoByName(context.Background(), todo.Name)
+	if err != nil {
+		return fmt.Errorf("error deleting todo by name: %w", err)
+	}
+
+	color.MsgSuccess(fmt.Sprintf("Todo %s deleted successfully", todo.Name))
 
 	return nil
 }
@@ -282,7 +292,7 @@ func (cfg *Config) updateDailyTodo() error {
 	// First, get all daily tasks BEFORE resetting them
 	dailyTasks, err := cfg.Queries.GetDailyTodos(ctx)
 	if err != nil {
-		return fmt.Errorf("Error getting daily tasks: %w", err)
+		return fmt.Errorf("error getting daily tasks: %w", err)
 	}
 
 	if len(dailyTasks) == 0 {


### PR DESCRIPTION
## Problem
- command `delete-by-name` was producing a false positive based on a wrong print of conclusion
- the logic of the command was quite wrong, stopping the correct deletion of the task

## Solution 
- fix `cfg.DeleteTodoByName` by first querying the `todo` and then passing `todo.Name` as a parameter for query `DeleteTodoByName`
- Change the output of the successful conclusion
- Add `deleteYes` to confirm the deletion of the task, because it is a destructive action and irreversible